### PR TITLE
[Client] #86 / 회원가입__ajax, 웹용 에러 모달, 태블릿/모바일 용 에러 노출 구현 

### DIFF
--- a/new/package-lock.json
+++ b/new/package-lock.json
@@ -2217,6 +2217,12 @@
         "@types/node": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
+      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==",
+      "dev": true
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -2334,6 +2340,27 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.11.tgz",
+      "integrity": "sha512-ofHbZMlp0Y2baOHgsWBQ4K3AttxY61bDMkwTiBOkPg7U6C/3UwwB5WaIx28JmSVi/eX3uFEMRo61BV22fDQIvg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.7.tgz",
+      "integrity": "sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/resolve": {

--- a/new/package.json
+++ b/new/package.json
@@ -46,6 +46,7 @@
     ]
   },
   "devDependencies": {
-    "@types/react-redux": "^7.1.16"
+    "@types/react-redux": "^7.1.16",
+    "@types/react-router-dom": "^5.1.7"
   }
 }

--- a/new/src/App.tsx
+++ b/new/src/App.tsx
@@ -1,7 +1,36 @@
+import { BrowserRouter, Link, Route, Switch } from "react-router-dom";
+import Login from "./Components/login/Login";
 import SignUp from "./Components/signup/SignUp";
 
 function App() {
-  return <SignUp></SignUp>;
+  return (
+    <BrowserRouter>
+      <div id="router">
+        <nav>
+          <ul>
+            <li>
+              <Link to="/">Home</Link>
+            </li>
+            <li>
+              <Link to="/login">로그인</Link>
+            </li>
+            <li>
+              <Link to="/signup">회원가입</Link>
+            </li>
+          </ul>
+        </nav>
+        <Switch>
+          <Route path="/login">
+            <Login />
+          </Route>
+          <Route path="/signup">
+            <SignUp />
+          </Route>
+          <Route path="/">{/* <Home /> */}</Route>
+        </Switch>
+      </div>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/new/src/Components/login/Login.tsx
+++ b/new/src/Components/login/Login.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Login = () => {
+  return <div></div>;
+};
+
+export default Login;

--- a/new/src/Components/modal/OneBtnModal.css
+++ b/new/src/Components/modal/OneBtnModal.css
@@ -1,0 +1,52 @@
+@font-face {
+  font-family: "neoL";
+  src: url("../../fonts/AppleSDGothicNeoL.ttf");
+}
+
+.onebtnModal__background {
+  position: absolute;
+  content: "";
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  top: 0;
+  left: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.onebtnModal__contain {
+  width: 370px;
+  height: 180px;
+  background-color: white;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.onbtnModal__message {
+  font-family: neoL;
+  font-size: 20px;
+}
+
+.onebtnModal__btn-contain {
+  margin-top: 20px;
+}
+
+.onebtnModal__btn {
+  font-family: neoL;
+  width: 63px;
+  height: 42px;
+  background-color: #619fd0;
+  color: white;
+  border: 0;
+  border-radius: 10px;
+  font-size: 14px;
+  margin-left: 15px;
+  margin-right: 15px;
+  margin-bottom: 10px;
+}

--- a/new/src/Components/modal/OneBtnModal.tsx
+++ b/new/src/Components/modal/OneBtnModal.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import { connect } from "react-redux";
+import "./OneBtnModal.css";
+
+const OneBtnModal = ({ message, info, handleFindModalClose }: any) => {
+  const [clickModal, setClickModal] = useState<boolean>(false);
+
+  const handleClickModal = () => {
+    setClickModal(true);
+    handleFindModalClose();
+    setClickModal(false);
+  };
+
+  return (
+    <>
+      {!clickModal ? (
+        <div className="onebtnModal__background">
+          <div className="onebtnModal__contain">
+            <p className="onbtnModal__message">{message}</p>
+            {info ? <p className="onbtnModal__info">{info}</p> : null}
+            <div className="onebtnModal__btn-contain">
+              <button className="onebtnModal__btn" onClick={handleClickModal}>
+                확인
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+const mapStateToProps = (state: any) => {
+  return { pageWidth: state };
+};
+
+export default connect(mapStateToProps)(OneBtnModal);

--- a/new/src/Components/signup/signUp.css
+++ b/new/src/Components/signup/signUp.css
@@ -28,6 +28,14 @@
   align-items: center;
 }
 
+.onbtnModal__info {
+  font-family: neoL;
+  font-size: 15px;
+  color: #6b6b6b;
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+
 @media all and (min-width: 1024px) {
   #signUpPage {
     background-color: #619fd0;
@@ -137,9 +145,16 @@
   #signUp__joinBtn-extend:hover {
     color: black;
   }
+
+  #userInfo__errorView {
+    display: none;
+  }
 }
 
 @media all and (min-width: 768px) and (max-width: 1023px) {
+  .onebtnModal__background {
+    display: none;
+  }
   #signUp__ment {
     font-family: neoB;
     font-size: 30px;
@@ -164,7 +179,6 @@
   .userInfo__contain {
     width: 538px;
     height: 105px;
-    /* margin-bottom: px; */
   }
 
   .userInfo__title-basic {
@@ -234,6 +248,9 @@
     font-size: 17px;
     color: #f45757;
   }
+  /* .onebtnModal__background {
+    display: none;
+  } */
 }
 
 @media all and (max-width: 768px) {

--- a/new/src/index.tsx
+++ b/new/src/index.tsx
@@ -4,9 +4,11 @@ import App from "./App";
 import { Provider } from "react-redux";
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { userInfoReducer } from "./reducers/userInfoReducer";
+import { pageWidthReducer } from "./reducers/pageWidthReducer";
 
 const RootReducer = combineReducers({
   userInfo: userInfoReducer,
+  pageWidth: pageWidthReducer,
 });
 
 const store = configureStore({

--- a/new/src/reducers/pageWidthReducer.ts
+++ b/new/src/reducers/pageWidthReducer.ts
@@ -1,0 +1,20 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  width: document.documentElement.clientWidth + 15,
+};
+
+const pageWidthSlice = createSlice({
+  name: "pageWidthSlice",
+  initialState,
+  reducers: {
+    changeCurrentPageWidth(state, action) {
+      const clientWidth = action.payload;
+      state.width = clientWidth + 15;
+    },
+  },
+});
+
+export const { changeCurrentPageWidth } = pageWidthSlice.actions;
+
+export const pageWidthReducer = pageWidthSlice.reducer;


### PR DESCRIPTION
pageWidth  상태를 이용 웹 / (모바일, 태블릿)구분하여 에러 모달 또는 에러 문구 노출

웹 > 가입 성공시 모달 안내 후 로그인 페이지 이동, 실패시 에러 모달 노출
모바일 > 가입 성공시 로그인 페이지 이동, 실패시 에러 문구 노출

실시간 클라이언트 width 를 탐색하여 저장하는 pageWidth 상태 리덕스 추가

