### PR TITLE
[Client] #88 / 모바일, 태블릿 모달 비노출 및 상태 관리

### DIFF
--- a/new/src/Components/modal/OneBtnModal.css
+++ b/new/src/Components/modal/OneBtnModal.css
@@ -50,3 +50,9 @@
   margin-right: 15px;
   margin-bottom: 10px;
 }
+
+@media all and (max-width: 1024px) {
+  .onebtnModal__background {
+    display: none;
+  }
+}

--- a/new/src/Components/signup/SignUp.tsx
+++ b/new/src/Components/signup/SignUp.tsx
@@ -59,6 +59,10 @@ const SignUp = ({ userInfo, pageWidth, ...rest }: any) => {
     } else {
       setDefaultBtnColor(true);
     }
+
+    if (pageWidth < 1024 && webError) {
+      setWebError(false);
+    }
   });
 
   const userInfoListItem = infoForm.map((item) => {

--- a/new/src/Components/signup/signUp.css
+++ b/new/src/Components/signup/signUp.css
@@ -152,9 +152,9 @@
 }
 
 @media all and (min-width: 768px) and (max-width: 1023px) {
-  .onebtnModal__background {
+  /* .onebtnModal__background {
     display: none;
-  }
+  } */
   #signUp__ment {
     font-family: neoB;
     font-size: 30px;


### PR DESCRIPTION
 OneBtnModal css, 웹 에러 모달이 떠있는 경우 미디어 쿼리로 모바일/태블릿에선 비노출 될 수 있도록 적용
 SignUp 컴포넌트, useEffect내 pageWidth가 모바일/태블릿일 경우 모달창 비노출 상태로 변경